### PR TITLE
RTCにdefaultのコンフィギュレーションセットを追加する

### DIFF
--- a/rtctree/component.py
+++ b/rtctree/component.py
@@ -1060,8 +1060,13 @@ class Component(TreeNode):
 
         '''
         with self._mutex:
+            
             if not set_name in self.conf_sets:
-                raise exceptions.NoSuchConfSetError(set_name)
+                if set_name == "default":
+                    self._conf.get_active_configuration_set()
+                else:
+                    raise exceptions.NoSuchConfSetError(set_name)
+                
             self._conf.activate_configuration_set(set_name)
 
     def set_conf_set_value(self, set_name, param, value):


### PR DESCRIPTION
RTC起動時にdefaultのコンフィギュレーションセットが追加されないため以下の問題が発生する。

- https://github.com/gbiggs/rtshell/issues/24

OpenRTM-aistにdefaultのコンフィギュレーションセットを追加する修正を行ったが、1.2.2以前のOpenRTM-aistには適用されないため、rtctree側にdefaultのコンフィギュレーションセットを追加する修正を行った。

- https://github.com/OpenRTM/OpenRTM-aist-Python/pull/244

