### PR TITLE
setup.pyのバージョン更新

### DIFF
--- a/rtctree/component.py
+++ b/rtctree/component.py
@@ -1060,8 +1060,13 @@ class Component(TreeNode):
 
         '''
         with self._mutex:
+            
             if not set_name in self.conf_sets:
-                raise exceptions.NoSuchConfSetError(set_name)
+                if set_name == "default":
+                    self._conf.get_active_configuration_set()
+                else:
+                    raise exceptions.NoSuchConfSetError(set_name)
+                
             self._conf.activate_configuration_set(set_name)
 
     def set_conf_set_value(self, set_name, param, value):

--- a/setup.py
+++ b/setup.py
@@ -138,8 +138,8 @@ build.sub_commands.append(('build_idl', None))
 install.sub_commands.append(('install_idl', None))
 
 
-setuptools.setup(name='rtctree',
-                 version='4.2.0',
+setuptools.setup(name='rtctree-aist',
+                 version='4.2.1',
                  description='API for interacting with running RT Components '
                  'and managing RTM-based systems.',
                  long_description='API for interacting with running RT '
@@ -156,6 +156,11 @@ setuptools.setup(name='rtctree',
                      'Natural Language :: English',
                      'Operating System :: OS Independent',
                      'Programming Language :: Python :: 2.7',
+                     'Programming Language :: Python :: 3.5',
+                     'Programming Language :: Python :: 3.6',
+                     'Programming Language :: Python :: 3.7',
+                     'Programming Language :: Python :: 3.8',
+                     'Programming Language :: Python :: 3.9',
                      'Topic :: Software Development',
                  ],
                  packages=setuptools.find_packages(),


### PR DESCRIPTION
rtsprofileのバージョンを4.1.3に更新した。
rtsprofileは以下のプロジェクトにアップロードするため、名前を`rtsprofile`から`rtsprofile-aist`に変更した。

- https://pypi.org/manage/project/rtctree-aist/releases/

対応するPythonのバージョンに3.5、3.6、3.7、3.8、3.9を追加した。