### PR TITLE
rtvlogコマンドが正常に実行できない問題の修正

### DIFF
--- a/rtctree/component.py
+++ b/rtctree/component.py
@@ -1027,7 +1027,7 @@ class Component(TreeNode):
             props = {'logger.log_level': level,
                     'logger.filter': filters}
             props = utils.dict_to_nvlist(props)
-            sprof = SDOPackage.ServiceProfile(id=uuid_val.get_bytes(),
+            sprof = SDOPackage.ServiceProfile(id=str(uuid_val),
                     interface_type=intf_type, service=obs._this(),
                     properties=props)
             conf = self.object.get_configuration()
@@ -1047,7 +1047,7 @@ class Component(TreeNode):
         if cb_id not in self._loggers:
             raise exceptions.NoLoggerError(cb_id, self.name)
         conf = self.object.get_configuration()
-        res = conf.remove_service_profile(cb_id.get_bytes())
+        res = conf.remove_service_profile(str(cb_id))
         del self._loggers[cb_id]
 
     ###########################################################################
@@ -1155,7 +1155,7 @@ class Component(TreeNode):
     def _enable_dynamic(self, enable=True):
         if enable:
             obs = sdo.RTCObserver(self)
-            uuid_val = uuid.uuid4().get_bytes()
+            uuid_val = str(uuid.uuid4())
             intf_type = obs._this()._NP_RepositoryId
             props = utils.dict_to_nvlist({'heartbeat.enable': 'YES',
                 'heartbeat.interval': '1.0',

--- a/rtctree/sdo.py
+++ b/rtctree/sdo.py
@@ -91,7 +91,7 @@ class RTCLogger(OpenRTM__POA.Logger):
 
     def publish(self, record):
         ts = record.time.sec + record.time.nsec / 1e9
-        self._cb(self._tgt.name, ts, loggername, level, message)
+        self._cb(self._tgt.name, ts, record.loggername, record.level, record.message)
 
 
 # vim: set expandtab tabstop=8 shiftwidth=4 softtabstop=4 textwidth=79


### PR DESCRIPTION
rtvlogコマンド実行時にRTC側でSDO サービスコンシューマを起動するが、ServiceProfileの初期化でエラーが発生する問題と、Loggerインターフェースのpublish関数実行時にエラーが発生するため、これらの問題を修正した。